### PR TITLE
メモリを使いすぎてしまう実装を修正

### DIFF
--- a/spcconverter/kiminonaha/kiminonaha.py
+++ b/spcconverter/kiminonaha/kiminonaha.py
@@ -50,7 +50,7 @@ def generate(image1, image2, output_path):
     images = [resize_height_base(img, height) for img in [image1, image2]]
     images[-1] = cv2.flip(images[-1], 1)
 
-    if images[0].shape[1] > center[1]:
+    if images[0].shape[1] > center[1] * 2:
         trim = (images[0].shape[1] - center[1]) // 2
         images = [image[:, trim:-trim] for image in images]
 
@@ -80,7 +80,7 @@ if __name__ == "__main__":
     images[-1] = cv2.flip(images[-1], 1)
 
     # 横幅が背景画像からはみ出ないようにトリミング
-    if images[0].shape[1] > center[1]:
+    if images[0].shape[1] > center[1] * 2:
         trim = (images[0].shape[1] - center[1]) // 2
         images = [image[:, trim:-trim] for image in images]
 

--- a/spcconverter/kiminonaha/kiminonaha.py
+++ b/spcconverter/kiminonaha/kiminonaha.py
@@ -50,8 +50,8 @@ def generate(image1, image2, output_path):
     images = [resize_height_base(img, height) for img in [image1, image2]]
     images[-1] = cv2.flip(images[-1], 1)
 
-    if images[0].shape[1] > center[1] * 2:
-        trim = (images[0].shape[1] - center[1]) // 2
+    if images[0].shape[1] // 2 > center[1]:
+        trim = images[0].shape[1] // 2 - center[1]
         images = [image[:, trim:-trim] for image in images]
 
     image = composite_image(background_image, images, center)
@@ -80,8 +80,8 @@ if __name__ == "__main__":
     images[-1] = cv2.flip(images[-1], 1)
 
     # 横幅が背景画像からはみ出ないようにトリミング
-    if images[0].shape[1] > center[1] * 2:
-        trim = (images[0].shape[1] - center[1]) // 2
+    if images[0].shape[1] // 2 > center[1]:
+        trim = images[0].shape[1] // 2 - center[1]
         images = [image[:, trim:-trim] for image in images]
 
     # 画像を背景画像に合成

--- a/spcconverter/main.py
+++ b/spcconverter/main.py
@@ -53,23 +53,21 @@ def convert_all(path_list: List[str]):
         image = remove_green_chromakey(path)
         return image
 
-    if len(path_list) % 2 != 0:
-        path_list.append(pkg_resources.resource_filename("spcconverter", "assets/kiminonaha/dummy.jpg"))
-    images = [load_and_chromakey(path) for path in path_list]
-
     def get_output_path(suffix):
         file_name = str(uuid.uuid4()) + suffix
-        print(file_name)
         output_path = os.path.join(settings.OUTPUT_IMAGE_DIR, file_name)
-        print(output_path)
         return output_path
 
-    random_index_list = random.sample(range(len(images)), len(images))
+    if len(path_list) % 2 != 0:
+        path_list.append(pkg_resources.resource_filename("spcconverter", "assets/kiminonaha/dummy.jpg"))
+
+    random_index_list = random.sample(range(len(path_list)), len(path_list))
     it = iter(random_index_list)
     for idx1, idx2 in zip(it, it):
-        # print(idx1, idx2)
+        image1 = load_and_chromakey(path_list[idx1])
+        image2 = load_and_chromakey(path_list[idx2])
         output_path = get_output_path(".png")
-        kiminonaha.generate(image1=images[idx1], image2=images[idx2], output_path=output_path)
+        kiminonaha.generate(image1=image1, image2=image2, output_path=output_path)
         output_path_list.append(output_path)
 
     return output_path_list


### PR DESCRIPTION
## 修正事項
- 大量の画像を処理することになった際に、メモリを大量に使ってしまうことが予想される実装になっていたため、処理の順番を修正した
- 画像の横幅が背景画像からはみ出てる場合にトリミングを行うが、その範囲が半分になってしまっていたため、その部分を修正した